### PR TITLE
cleanup - DLPX-62965, LX-1789 and update plugin gems versions

### DIFF
--- a/config/projects/td-agent3.rb
+++ b/config/projects/td-agent3.rb
@@ -3,9 +3,12 @@ require 'fileutils'
 require 'rubygems'
 
 name "td-agent"
-maintainer "Treasure Data, Inc"
-homepage "http://treasuredata.com"
-description "Treasure Agent: A data collector for Treasure Data"
+#maintainer "Treasure Data, Inc"
+#homepage "http://treasuredata.com"
+#description "Treasure Agent: A data collector for Treasure Data"
+maintainer "Delphix Engineering <eng@delphix.com>"
+homepage "https://www.delphix.com"
+description "Insight Data pipeline"
 
 if windows?
   install_dir "#{default_root}/opt/#{name}"
@@ -32,18 +35,21 @@ override :postgresql, :version => '9.6.9'
 override :fluentd, :version => '2903f22d7b6485a97b47c4386ab6c6e86d269a15' # v1.4.2
 
 # td-agent dependencies/components
-dependency "td-agent"
-dependency "td-agent-files"
-# comment below two, we don't need them
+#dependency "td-agent"
+#dependency "td-agent-files"
 #dependency "td"
 #dependency "td-agent-ui" # fluentd-ui doesn't work with ruby 2.4 because some gems depend on json 1.8
-dependency "td-agent-cleanup"
+#dependency "td-agent-cleanup"
+
+# Use core td-agent and custom Delphix ones below
+dependency "td-agent"
+dependency "delphix-fluentd-files"
+dependency "delphix-fluentd-cleanup"
+# Add Delphix custom splunk-hec plugin
+dependency "splunk-hec"
 
 # version manifest file
 dependency "version-manifest"
-
-# Add Delphix custom splunk-hec plugin
-dependency "splunk-hec"
 
 case ohai["os"]
 when "linux"

--- a/config/software/delphix-fluentd-cleanup.rb
+++ b/config/software/delphix-fluentd-cleanup.rb
@@ -1,0 +1,27 @@
+name "delphix-fluentd-cleanup"
+#version '' # git ref
+
+dependency "td-agent"
+dependency "delphix-fluentd-files"
+
+build do
+  block do
+    project_name = project.name
+    rb_major, rb_minor, rb_teeny = project.overrides[:ruby][:version].split("-", 2).first.split(".", 3)
+    gem_dir_version = "#{rb_major}.#{rb_minor}.0" # gem path's teeny version is always 0
+
+    # remove unnecessary files
+    FileUtils.rm_f(Dir.glob("/opt/#{project_name}/embedded/lib/ruby/gems/#{gem_dir_version}/cache/*.gem"))
+    FileUtils.rm_rf(Dir.glob("/opt/#{project_name}/embedded/share/{doc,gtk-doc,terminfo}"))
+    Dir.glob("/opt/#{project_name}/embedded/lib/ruby/gems/#{gem_dir_version}/gems/*").each { |gem_dir|
+      if File.exist?("#{gem_dir}/ext")
+        FileUtils.rm_f(Dir.glob("#{gem_dir}/ext/**/*.o"))
+      end
+      FileUtils.rm_rf(["#{gem_dir}/test", "{gem_dir}/spec"])
+    }
+
+    if windows?
+      FileUtils.rm_rf("/opt/#{project_name}/etc/init.d")
+    end
+  end
+end

--- a/config/software/delphix-fluentd-files.rb
+++ b/config/software/delphix-fluentd-files.rb
@@ -1,0 +1,65 @@
+name "delphix-fluentd-files"
+#version '' # git ref
+
+dependency "td-agent"
+
+# This software sets up delphix-fluentd related files.
+# It customizes the default td-agent package for delphix-fluentd, see comments below.
+# Separating file into td-agent.rb and delphix-fluentd-files.rb is for speed up package building
+
+build do
+  block do
+    # setup related files
+    pkg_type = project.packagers_for_system.first.id.to_s
+    root_path = "/" # for ERB
+    install_path = project.install_dir # for ERB
+    project_name = project.name # for ERB
+    is_td_agent2 = project.build_version.start_with?('2.')
+    project_name_snake = project.name.gsub('-', '_') # for variable names in ERB
+    rb_major, rb_minor, rb_teeny = project.overrides[:ruby][:version].split("-", 2).first.split(".", 3)
+    gem_dir_version = "#{rb_major}.#{rb_minor}.0" # gem path's teeny version is always 0
+    install_message = nil
+
+    template = ->(*parts) { File.join('templates', *parts) }
+    generate_from_template = ->(dst, src, erb_binding, opts={}) {
+      mode = opts.fetch(:mode, 0755)
+      destination = dst.gsub('td-agent', project.name)
+      FileUtils.mkdir_p File.dirname(destination)
+      File.open(destination, 'w', mode) do |f|
+        f.write ERB.new(File.read(src), nil, '<>').result(erb_binding)
+      end
+    }
+
+    if File.exist?(template.call('INSTALL_MESSAGE'))
+      install_message = File.read(template.call('INSTALL_MESSAGE'))
+    end
+
+    # copy pre/post scripts into omnibus path (./package-scripts/td-agentN)
+    FileUtils.mkdir_p(project.package_scripts_path)
+    Dir.glob(File.join(project.package_scripts_path, '*')).each { |f|
+      FileUtils.rm_f(f) if File.file?(f)
+    }
+    # templates/package-scripts/td-agent/xxxx/* -> ./package-scripts/td-agentN
+    Dir.glob(template.call('package-scripts', 'td-agent', pkg_type, '*')).each { |f|
+      package_script = File.join(project.package_scripts_path, File.basename(f))
+      generate_from_template.call package_script, f, binding, mode: 0755
+    }
+
+    #
+    # Delphix customizations (compare to td-agent-files.rb):
+    #  - Skip setup plist - since we only build for debian
+    #  - Skip setup init.d file - since we use systemd
+    #  - Skip systemd unit file - since its delivered via app gate
+    #  - Skip conf file (/etc/td-agent) - since its created dynamically by app stack (/etc/fluent/fluent.conf)
+    #  - Skip ./resources/etc -> INSTALL_PATH/etc
+    #  - Only need td-agent and td-agent-gem scripts to be delivered as part of the package.
+    #
+
+    ["td-agent", "td-agent-gem"].each { |command|
+      sbin_path = File.join(install_path, 'usr', 'sbin', command)
+      # templates/usr/sbin/yyyy.erb -> INSTALL_PATH/usr/sbin/yyyy
+      generate_from_template.call sbin_path, template.call('usr', 'sbin', "#{command}.erb"), binding, mode: 0755
+    }
+
+  end
+end

--- a/delphix_plugin_gems.rb
+++ b/delphix_plugin_gems.rb
@@ -11,7 +11,8 @@ else
   download "aws-sdk-kms", "1.16.0"
   download "aws-sdk-sqs", "1.13.0"
   download "aws-sdk-s3", "1.36.0"
-  download "fluent-plugin-s3", "1.1.9"
+  download "aws-sdk-cloudwatchlogs", "1.18.0"
+  download "fluent-plugin-s3", "1.1.10"
   download "fluent-plugin-kinesis", "3.1.0"
 end
 if td_agent_2?
@@ -30,16 +31,18 @@ end
 if td_agent_2?
   download "fluent-plugin-rewrite-tag-filter", "1.6.0"
 else
-  download "fluent-plugin-rewrite-tag-filter", "2.1.1"
+  download "fluent-plugin-rewrite-tag-filter", "2.2.0"
 end
 download "ruby-kafka", "0.7.6"
 unless windows?
   download "rdkafka", "0.4.2"
 end
-download "fluent-plugin-kafka", "0.9.2"
+download "fluent-plugin-kafka", "0.9.4"
 unless td_agent_2?
   download "elasticsearch", "6.3.0"
-  download "fluent-plugin-elasticsearch", "3.4.3"
+  download "fluent-plugin-elasticsearch", "3.5.1"
+  download "prometheus-client", "0.9.0"
+  download "fluent-plugin-prometheus", "1.4.0"
 end
 if td_agent_2?
   download "fluent-plugin-record-modifier", "0.6.2"
@@ -49,8 +52,9 @@ end
 download "fluent-plugin-multi-format-parser", "1.0.0"
 download "fluent-plugin-out-http", "1.2.0"
 download "fluent-plugin-datadog", "0.10.5"
-download "fluent-plugin-prometheus", "1.3.0"
 download "fluent-plugin-google-cloud", "0.7.11"
 download "fluent-plugin-slack", "0.6.7"
 download "fluent-plugin-grok-parser", "2.5.1"
 download "fluent-plugin-dstat", "1.0.0"
+download "fluent-plugin-cloudwatch-logs", "0.7.3"
+download "fluent-plugin-influxdb", "2.0.0"

--- a/templates/package-scripts/td-agent/deb/postinst
+++ b/templates/package-scripts/td-agent/deb/postinst
@@ -66,10 +66,7 @@ update_conffile() {
 
 case "$1" in
     configure)
-        add_system_user
-        add_directories
-        fixperms
-        update_conffile /etc/<%= project_name %>/<%= project_name %>.conf ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl
+        :
         ;;
     abort-upgrade|abort-deconfigure|abort-remove)
         :
@@ -81,37 +78,10 @@ case "$1" in
 esac
 
 
-cp -f --remove-destination ${<%= project_name_snake %>_dir}/etc/init.d/<%= project_name %> /etc/init.d/<%= project_name %>
 cp -f ${<%= project_name_snake %>_dir}/usr/sbin/<%= project_name %> /usr/sbin/<%= project_name %>
 chmod 755 /usr/sbin/<%= project_name %>
 cp -f ${<%= project_name_snake %>_dir}/usr/sbin/<%= project_name %>-gem /usr/sbin/<%= project_name %>-gem
 chmod 755 /usr/sbin/<%= project_name %>-gem
-if [ -f ${<%= project_name_snake %>_dir}/usr/sbin/<%= project_name %>-ui ]; then
-    cp -f ${<%= project_name_snake %>_dir}/usr/sbin/<%= project_name %>-ui /usr/sbin/<%= project_name %>-ui
-    chmod 755 /usr/sbin/<%= project_name %>-ui
-fi
-if [ -f ${<%= project_name_snake %>_dir}/usr/bin/td ]; then
-    cp -f ${<%= project_name_snake %>_dir}/usr/bin/td /usr/bin/td
-    chmod 755 /usr/bin/td
-fi
-
-if [ -d "/etc/logrotate.d/" ]; then
-  cp -f ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/logrotate.d/<%= project_name %>.logrotate /etc/logrotate.d/<%= project_name %>
-fi
-
-if [ ! -e "/etc/default/<%= project_name %>" ]; then
-  cat > /etc/default/<%= project_name %> <<EOF
-# This file is sourced by /bin/sh from /etc/init.d/<%= project_name %>
-# Options to pass to <%= project_name %>
-TD_AGENT_OPTIONS=""
-
-EOF
-fi
-
-if [ -d "/lib/systemd/system/" ]; then
-    cp -f ${<%= project_name_snake %>_dir}/etc/systemd/<%= project_name %>.service /lib/systemd/system/
-    chmod 644 /lib/systemd/system/<%= project_name %>.service
-fi
 
 <% if install_message %>
 if [ "$1" = "configure" ]; then

--- a/templates/package-scripts/td-agent/deb/postrm
+++ b/templates/package-scripts/td-agent/deb/postrm
@@ -3,34 +3,8 @@
 set -e
 
 if [ "$1" = "purge" ]; then
-        rm -f /etc/default/<%= project_name %>
-        rm -f /etc/<%= project_name %>/<%= project_name %>.conf
-	dpkg-statoverride --list /etc/<%= project_name %> > /dev/null && \
-		dpkg-statoverride --remove /etc/<%= project_name %>
-	rm -f /var/run/<%= project_name %>/*
-	dpkg-statoverride --list /var/run/<%= project_name %> > /dev/null && \
-		dpkg-statoverride --remove /var/run/<%= project_name %>
-	rm -rf /var/log/<%= project_name %>/buffer
-	rm -rf /var/log/<%= project_name %>/*
-	dpkg-statoverride --list /var/log/<%= project_name %> > /dev/null && \
-		dpkg-statoverride --remove /var/log/<%= project_name %>
-
-    rm /etc/init.d/<%= project_name %>
     rm /usr/sbin/<%= project_name %>
     rm /usr/sbin/<%= project_name %>-gem
-
-    getent passwd <%= project_name %> && userdel -r <%= project_name %>
-
-    if [ -f /usr/sbin/<%= project_name %>-ui ]; then
-        rm /usr/sbin/<%= project_name %>-ui
-    fi
-    if [ -f /usr/bin/td ]; then
-        rm /usr/bin/td
-    fi
-    if [ -f /etc/logrotate.d/<%= project_name %> ]; then
-        rm /etc/logrotate.d/<%= project_name %>
-    fi
-
 fi
 
 # Automatically added by dh_makeshlibs

--- a/templates/usr/sbin/td-agent.erb
+++ b/templates/usr/sbin/td-agent.erb
@@ -1,7 +1,6 @@
 #!<%= install_path %>/embedded/bin/ruby
 ENV["GEM_HOME"]="<%= install_path %>/embedded/lib/ruby/gems/<%= gem_dir_version %>/"
 ENV["GEM_PATH"]="<%= install_path %>/embedded/lib/ruby/gems/<%= gem_dir_version %>/"
-ENV["FLUENT_CONF"]="/etc/<%= project.name %>/<%= project.name %>.conf"
-ENV["FLUENT_PLUGIN"]="/etc/<%= project.name %>/plugin"
-ENV["FLUENT_SOCKET"]="/var/run/<%= project.name %>/<%= project.name %>.sock"
+ENV["FLUENT_CONF"]="/etc/fluent/fluent.conf"
+ENV["FLUENT_SOCKET"]="/var/run/fluent/fluentd.sock"
 load "<%= install_path %>/embedded/bin/fluentd"


### PR DESCRIPTION
DLPX-62965 Command "sudo logrotate /etc/logrotate.conf" fails because it is not able to find td-agent.log file
LX-1789 The td-agent.service should be masked to disable usage
Update Delphix plugin gems versions to match upstream td-agent 3.4.1 version

To resolve DLPX-62965 and LX-1789, this PR cleans up our td-agent package customization by:
-  Adding custom `delphix-fluentd-files.rb` and `delphix-fluentd-cleanup.rb` to package only the core `td-agent` and `td-agent-gem` artifacts we need for `delphix-fluentd.service`
- Modifies `deb/postinst` and `deb/postrm` scripts to deliver only `td-agent` and `td-agent-gem`

