### PR TITLE
Update plugin gems to match upstream 3.5.0 release

### DIFF
--- a/delphix_plugin_gems.rb
+++ b/delphix_plugin_gems.rb
@@ -5,14 +5,14 @@ if td_agent_2?
   download "fluent-plugin-s3", "0.8.7"
 else
   download "jmespath", "1.4.0"
-  download "aws-partitions", "1.149.0"
+  download "aws-partitions", "1.195.0"
   download "aws-sigv4", "1.1.0"
-  download "aws-sdk-core", "3.48.3"
-  download "aws-sdk-kms", "1.16.0"
-  download "aws-sdk-sqs", "1.13.0"
-  download "aws-sdk-s3", "1.36.0"
+  download "aws-sdk-core", "3.61.2"
+  download "aws-sdk-kms", "1.24.0"
+  download "aws-sdk-sqs", "1.20.0"
+  download "aws-sdk-s3", "1.46.0"
+  download "fluent-plugin-s3", "1.1.11"
   download "aws-sdk-cloudwatchlogs", "1.18.0"
-  download "fluent-plugin-s3", "1.1.10"
   download "fluent-plugin-kinesis", "3.1.0"
 end
 if td_agent_2?
@@ -26,23 +26,23 @@ download "webhdfs", "0.8.0"
 if td_agent_2?
   download "fluent-plugin-webhdfs", "0.7.1"
 else
-  download "fluent-plugin-webhdfs", "1.2.3"
+  download "fluent-plugin-webhdfs", "1.2.4"
 end
 if td_agent_2?
   download "fluent-plugin-rewrite-tag-filter", "1.6.0"
 else
   download "fluent-plugin-rewrite-tag-filter", "2.2.0"
 end
-download "ruby-kafka", "0.7.6"
+download "ruby-kafka", "0.7.10"
 unless windows?
-  download "rdkafka", "0.4.2"
+  download "rdkafka", "0.6.0"
 end
-download "fluent-plugin-kafka", "0.9.4"
+download "fluent-plugin-kafka", "0.11.1"
 unless td_agent_2?
-  download "elasticsearch", "6.3.0"
-  download "fluent-plugin-elasticsearch", "3.5.1"
+  download "elasticsearch", "6.8.0"
+  download "fluent-plugin-elasticsearch", "3.5.4"
   download "prometheus-client", "0.9.0"
-  download "fluent-plugin-prometheus", "1.4.0"
+  download "fluent-plugin-prometheus", "1.5.0"
 end
 if td_agent_2?
   download "fluent-plugin-record-modifier", "0.6.2"


### PR DESCRIPTION
Upstream 3.5.0 release updated some of the plugin gems (in `plugin_gems.rb`), so update correspondingly in `delphix_plugin_gems.rb`
